### PR TITLE
Train bug fix

### DIFF
--- a/dro/utils/attacks.py
+++ b/dro/utils/attacks.py
@@ -69,16 +69,6 @@ def iterative_fgsm(model, x, y, ord, eps: float, eps_iter: float, nb_iter=1, cli
     return adv_x
 
 
-def clip(x: tf.Tensor, eps: float):
-    """Implements the CLIP function described in Kurakin et al. (sec 2.1)"""
-    # These Tensors give the elemnt-wise upper and lower bounds for the matrix
-    upper_bound = x + eps
-    lower_bound = x - eps
-    clipped_upper = tf.minimum(upper_bound, x)
-    clipped = tf.maximum(clipped_upper, lower_bound)
-    return clipped
-
-
 class IterativeFastGradientMethod(Attack):
 
     def __init__(self, model, sess=None, dtypestr='float32', **kwargs):

--- a/dro/utils/cleverhans.py
+++ b/dro/utils/cleverhans.py
@@ -65,10 +65,7 @@ def get_adversarial_acc_metric(model: keras.Model, attack: Attack, attack_params
         x_adv = generate_attack(attack, model.input, attack_params)
         # Consider the attack to be constant
         x_adv = tf.stop_gradient(x_adv)
-
         # Accuracy on the adversarial examples
-        print(x_adv)
-        print(model.input)
         preds_adv = model(x_adv)
         return keras.metrics.categorical_accuracy(y, preds_adv)
 
@@ -81,10 +78,7 @@ def get_adversarial_auc_metric(model: keras.Model, attack: Attack, attack_params
         x_adv = generate_attack(attack, model.input, attack_params)
         # Consider the attack to be constant
         x_adv = tf.stop_gradient(x_adv)
-
         # Accuracy on the adversarial examples
-        print(x_adv)
-        print(model.input)
         preds_adv = model(x_adv)
         return tf.metrics.auc(y, preds_adv)
 

--- a/dro/utils/cleverhans.py
+++ b/dro/utils/cleverhans.py
@@ -72,19 +72,6 @@ def get_adversarial_acc_metric(model: keras.Model, attack: Attack, attack_params
     return adv_acc
 
 
-def get_adversarial_auc_metric(model: keras.Model, attack: Attack, attack_params: dict):
-    def adv_auc(y, _):
-        # Generate adversarial examples
-        x_adv = generate_attack(attack, model.input, attack_params)
-        # Consider the attack to be constant
-        x_adv = tf.stop_gradient(x_adv)
-        # Accuracy on the adversarial examples
-        preds_adv = model(x_adv)
-        return tf.metrics.auc(y, preds_adv)
-
-    return adv_auc
-
-
 def get_adversarial_loss(model: keras.Model, attack: Attack,
                          fgsm_params: dict,
                          adv_multiplier: float):

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -104,11 +104,11 @@ def get_data_type_and_metric_from_name(name, sep="_"):
     return data, metric_name
 
 
-# def run_variable_initializers(sess):
-#     init = tf.group(tf.global_variables_initializer(),
-#                     tf.local_variables_initializer())
-#     sess.run(init)
-#     return
+def run_variable_initializers(sess):
+    init = tf.group(tf.global_variables_initializer(),
+                    tf.local_variables_initializer())
+    sess.run(init)
+    return
 
 
 def mnist_tutorial(label_smoothing=0.1):

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -192,7 +192,9 @@ def mnist_tutorial(label_smoothing=0.1):
                   "epochs": FLAGS.epochs,
                   "validation_steps": steps_per_val_epoch}
 
+
     if FLAGS.train_base:  # Base model training
+
 
         vgg_model_base = vggface2_model(dropout_rate=FLAGS.dropout_rate,
                                         activation='softmax')
@@ -201,6 +203,8 @@ def mnist_tutorial(label_smoothing=0.1):
         attack = get_attack(FLAGS, vgg_model_base, sess)
         print("[INFO] using attack {} with params {}".format(FLAGS.attack, attack_params))
         adv_acc_metric = get_adversarial_acc_metric(vgg_model_base, attack, attack_params)
+        # Initialize the variables; this is required for the auc computation.
+        run_variable_initializers(sess)
         adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
         model_compile_args_base = get_model_compile_args(
             FLAGS, loss=tf.keras.losses.CategoricalCrossentropy(from_logits=False),
@@ -216,9 +220,6 @@ def mnist_tutorial(label_smoothing=0.1):
 
         print("[INFO] training base model")
         callbacks_base = make_callbacks(FLAGS, is_adversarial=False)
-
-        # Initialize the variables; this is required for the auc computation.
-        run_variable_initializers(sess)
 
         vgg_model_base.fit(train_ds.dataset, callbacks=callbacks_base,
                            validation_data=val_ds.dataset, **train_args)

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -201,13 +201,13 @@ def mnist_tutorial(label_smoothing=0.1):
         attack = get_attack(FLAGS, vgg_model_base, sess)
         print("[INFO] using attack {} with params {}".format(FLAGS.attack, attack_params))
         adv_acc_metric = get_adversarial_acc_metric(vgg_model_base, attack, attack_params)
-        # adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
+        adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
         model_compile_args_base = get_model_compile_args(
             FLAGS, loss=tf.keras.losses.CategoricalCrossentropy(from_logits=False),
             metrics_to_add=[
                 adv_acc_metric,
                 tf.keras.metrics.AUC(),
-                # adv_auc_metric
+                adv_auc_metric
             ]
         )
 
@@ -218,7 +218,7 @@ def mnist_tutorial(label_smoothing=0.1):
         callbacks_base = make_callbacks(FLAGS, is_adversarial=False)
 
         # Initialize the variables; this is required for the auc computation.
-        # run_variable_initializers(sess)
+        run_variable_initializers(sess)
 
         vgg_model_base.fit(train_ds.dataset, callbacks=callbacks_base,
                            validation_data=val_ds.dataset, **train_args)

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -42,7 +42,8 @@ python3 scripts/train_vggface2_cleverhans.py \
     --train_dir ${DIR}/annotated_partitioned_by_label/train/${LABEL} \
     --epochs $EPOCHS \
     --attack IterativeFastGradientMethod \
-    --attack_params "{\"eps\": $SS, \"nb_iter\": 8, \"eps_iter\": 0.004, \"clip_min\": null, \"clip_max\": null}" \
+    --attack_params "{\"eps\": $SS, \"nb_iter\": 8, \"eps_iter\": 0.004, \"clip_min\":
+    null, \"clip_max\": null}" \
     --adv_multiplier 0.2 \
     --anno_dir ${DIR}/anno
 
@@ -203,7 +204,12 @@ def mnist_tutorial(label_smoothing=0.1):
         adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
         model_compile_args_base = get_model_compile_args(
             FLAGS, loss=tf.keras.losses.CategoricalCrossentropy(from_logits=False),
-            metrics_to_add=[adv_acc_metric, tf.keras.metrics.AUC(), adv_auc_metric])
+            metrics_to_add=[
+                adv_acc_metric,
+                # tf.keras.metrics.AUC(),
+                # adv_auc_metric
+            ]
+        )
 
         vgg_model_base.compile(**model_compile_args_base)
         vgg_model_base.summary()
@@ -254,9 +260,13 @@ def mnist_tutorial(label_smoothing=0.1):
                                                         attack_params)
 
         model_compile_args_adv = get_model_compile_args(
-            FLAGS, loss=adv_loss_adv, metrics_to_add=[adv_acc_metric_adv,
-                                                      tf.keras.metrics.AUC(),
-                                                      adv_auc_metric_adv])
+            FLAGS, loss=adv_loss_adv,
+            metrics_to_add=[
+                adv_acc_metric_adv,
+                # tf.keras.metrics.AUC(),
+                # adv_auc_metric_adv
+            ]
+        )
 
         vgg_model_adv.compile(**model_compile_args_adv)
         print("[INFO] training adversarial model")

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -192,6 +192,8 @@ def mnist_tutorial(label_smoothing=0.1):
                   "epochs": FLAGS.epochs,
                   "validation_steps": steps_per_val_epoch}
 
+    # Initialize the variables; this is required for the auc computation.
+    run_variable_initializers(sess)
 
     if FLAGS.train_base:  # Base model training
 
@@ -203,8 +205,6 @@ def mnist_tutorial(label_smoothing=0.1):
         attack = get_attack(FLAGS, vgg_model_base, sess)
         print("[INFO] using attack {} with params {}".format(FLAGS.attack, attack_params))
         adv_acc_metric = get_adversarial_acc_metric(vgg_model_base, attack, attack_params)
-        # Initialize the variables; this is required for the auc computation.
-        run_variable_initializers(sess)
         adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
         model_compile_args_base = get_model_compile_args(
             FLAGS, loss=tf.keras.losses.CategoricalCrossentropy(from_logits=False),

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -31,19 +31,8 @@ python3 scripts/train_vggface2_cleverhans.py \
     --test_dir ${DIR}/annotated_partitioned_by_label/test/${LABEL} \
     --train_dir ${DIR}/annotated_partitioned_by_label/train/${LABEL} \
     --epochs $EPOCHS \
-    --attack BasicIterativeMethod \
-    --attack_params "{\"eps\": $SS, \"nb_iter\": 8, \"eps_iter\": 0.004}" \
-    --adv_multiplier 0.2 \
-    --anno_dir ${DIR}/anno
-
-python3 scripts/train_vggface2_cleverhans.py \
-    --label_name $LABEL \
-    --test_dir ${DIR}/annotated_partitioned_by_label/test/${LABEL} \
-    --train_dir ${DIR}/annotated_partitioned_by_label/train/${LABEL} \
-    --epochs $EPOCHS \
     --attack IterativeFastGradientMethod \
-    --attack_params "{\"eps\": $SS, \"nb_iter\": 8, \"eps_iter\": 0.004, \"clip_min\":
-    null, \"clip_max\": null}" \
+    --attack_params "{\"eps\": $SS, \"nb_iter\": 8, \"eps_iter\": 0.004, \"clip_min\": null, \"clip_max\": null}" \
     --adv_multiplier 0.2 \
     --anno_dir ${DIR}/anno
 

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -104,11 +104,11 @@ def get_data_type_and_metric_from_name(name, sep="_"):
     return data, metric_name
 
 
-def run_variable_initializers(sess):
-    init = tf.group(tf.global_variables_initializer(),
-                    tf.local_variables_initializer())
-    sess.run(init)
-    return
+# def run_variable_initializers(sess):
+#     init = tf.group(tf.global_variables_initializer(),
+#                     tf.local_variables_initializer())
+#     sess.run(init)
+#     return
 
 
 def mnist_tutorial(label_smoothing=0.1):
@@ -218,7 +218,7 @@ def mnist_tutorial(label_smoothing=0.1):
         callbacks_base = make_callbacks(FLAGS, is_adversarial=False)
 
         # Initialize the variables; this is required for the auc computation.
-        run_variable_initializers(sess)
+        # run_variable_initializers(sess)
 
         vgg_model_base.fit(train_ds.dataset, callbacks=callbacks_base,
                            validation_data=val_ds.dataset, **train_args)
@@ -273,7 +273,7 @@ def mnist_tutorial(label_smoothing=0.1):
         callbacks_adv = make_callbacks(FLAGS, is_adversarial=True)
 
         # Initialize the variables; this is required for the auc computation.
-        run_variable_initializers(sess)
+        # run_variable_initializers(sess)
 
         vgg_model_adv.fit(train_ds.dataset, callbacks=callbacks_adv,
                           validation_data=val_ds.dataset, **train_args)

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -201,7 +201,7 @@ def mnist_tutorial(label_smoothing=0.1):
         attack = get_attack(FLAGS, vgg_model_base, sess)
         print("[INFO] using attack {} with params {}".format(FLAGS.attack, attack_params))
         adv_acc_metric = get_adversarial_acc_metric(vgg_model_base, attack, attack_params)
-        adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
+        # adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
         model_compile_args_base = get_model_compile_args(
             FLAGS, loss=tf.keras.losses.CategoricalCrossentropy(from_logits=False),
             metrics_to_add=[
@@ -256,8 +256,8 @@ def mnist_tutorial(label_smoothing=0.1):
                                             FLAGS.adv_multiplier)
         adv_acc_metric_adv = get_adversarial_acc_metric(vgg_model_adv, attack,
                                                         attack_params)
-        adv_auc_metric_adv = get_adversarial_auc_metric(vgg_model_adv, attack,
-                                                        attack_params)
+        # adv_auc_metric_adv = get_adversarial_auc_metric(vgg_model_adv, attack,
+        #                                                 attack_params)
 
         model_compile_args_adv = get_model_compile_args(
             FLAGS, loss=adv_loss_adv,

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -76,8 +76,7 @@ from dro.utils.training_utils import make_callbacks, get_n_from_file_pattern, \
 from dro.datasets import ImageDataset
 from dro.utils.flags import define_training_flags, define_adv_training_flags
 from dro.utils.cleverhans import get_attack, get_adversarial_acc_metric, \
-    get_adversarial_loss, attack_params_from_flags, get_model_compile_args, \
-    get_adversarial_auc_metric
+    get_adversarial_loss, attack_params_from_flags, get_model_compile_args
 from dro import keys
 from dro.utils.vggface import make_vgg_file_pattern
 

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -105,8 +105,10 @@ def get_data_type_and_metric_from_name(name, sep="_"):
 
 
 def run_variable_initializers(sess):
-    init = tf.group(tf.global_variables_initializer(),
-                    tf.local_variables_initializer())
+    init = tf.group(
+        # tf.global_variables_initializer(),
+        tf.local_variables_initializer()
+    )
     sess.run(init)
     return
 
@@ -192,9 +194,7 @@ def mnist_tutorial(label_smoothing=0.1):
                   "epochs": FLAGS.epochs,
                   "validation_steps": steps_per_val_epoch}
 
-
     if FLAGS.train_base:  # Base model training
-
 
         vgg_model_base = vggface2_model(dropout_rate=FLAGS.dropout_rate,
                                         activation='softmax')
@@ -202,10 +202,10 @@ def mnist_tutorial(label_smoothing=0.1):
         # Initialize the attack object
         attack = get_attack(FLAGS, vgg_model_base, sess)
         print("[INFO] using attack {} with params {}".format(FLAGS.attack, attack_params))
-        # Initialize the variables; this is required for the auc computation.
-        run_variable_initializers(sess)
         adv_acc_metric = get_adversarial_acc_metric(vgg_model_base, attack, attack_params)
         adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
+        # Initialize the variables; this is required for the auc computation.
+        run_variable_initializers(sess)
         model_compile_args_base = get_model_compile_args(
             FLAGS, loss=tf.keras.losses.CategoricalCrossentropy(from_logits=False),
             metrics_to_add=[

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -192,8 +192,6 @@ def mnist_tutorial(label_smoothing=0.1):
                   "epochs": FLAGS.epochs,
                   "validation_steps": steps_per_val_epoch}
 
-    # Initialize the variables; this is required for the auc computation.
-    run_variable_initializers(sess)
 
     if FLAGS.train_base:  # Base model training
 
@@ -204,6 +202,8 @@ def mnist_tutorial(label_smoothing=0.1):
         # Initialize the attack object
         attack = get_attack(FLAGS, vgg_model_base, sess)
         print("[INFO] using attack {} with params {}".format(FLAGS.attack, attack_params))
+        # Initialize the variables; this is required for the auc computation.
+        run_variable_initializers(sess)
         adv_acc_metric = get_adversarial_acc_metric(vgg_model_base, attack, attack_params)
         adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
         model_compile_args_base = get_model_compile_args(

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -104,15 +104,6 @@ def get_data_type_and_metric_from_name(name, sep="_"):
     return data, metric_name
 
 
-def run_variable_initializers(sess):
-    init = tf.group(
-        # tf.global_variables_initializer(),
-        tf.local_variables_initializer()
-    )
-    sess.run(init)
-    return
-
-
 def mnist_tutorial(label_smoothing=0.1):
     """
     MNIST CleverHans tutorial
@@ -203,15 +194,12 @@ def mnist_tutorial(label_smoothing=0.1):
         attack = get_attack(FLAGS, vgg_model_base, sess)
         print("[INFO] using attack {} with params {}".format(FLAGS.attack, attack_params))
         adv_acc_metric = get_adversarial_acc_metric(vgg_model_base, attack, attack_params)
-        adv_auc_metric = get_adversarial_auc_metric(vgg_model_base, attack, attack_params)
-        # Initialize the variables; this is required for the auc computation.
-        run_variable_initializers(sess)
+
         model_compile_args_base = get_model_compile_args(
             FLAGS, loss=tf.keras.losses.CategoricalCrossentropy(from_logits=False),
             metrics_to_add=[
                 adv_acc_metric,
                 tf.keras.metrics.AUC(),
-                adv_auc_metric
             ]
         )
 
@@ -257,15 +245,12 @@ def mnist_tutorial(label_smoothing=0.1):
                                             FLAGS.adv_multiplier)
         adv_acc_metric_adv = get_adversarial_acc_metric(vgg_model_adv, attack,
                                                         attack_params)
-        # adv_auc_metric_adv = get_adversarial_auc_metric(vgg_model_adv, attack,
-        #                                                 attack_params)
 
         model_compile_args_adv = get_model_compile_args(
             FLAGS, loss=adv_loss_adv,
             metrics_to_add=[
                 adv_acc_metric_adv,
                 tf.keras.metrics.AUC(),
-                # adv_auc_metric_adv
             ]
         )
 

--- a/scripts/train_vggface2_cleverhans.py
+++ b/scripts/train_vggface2_cleverhans.py
@@ -206,7 +206,7 @@ def mnist_tutorial(label_smoothing=0.1):
             FLAGS, loss=tf.keras.losses.CategoricalCrossentropy(from_logits=False),
             metrics_to_add=[
                 adv_acc_metric,
-                # tf.keras.metrics.AUC(),
+                tf.keras.metrics.AUC(),
                 # adv_auc_metric
             ]
         )
@@ -263,7 +263,7 @@ def mnist_tutorial(label_smoothing=0.1):
             FLAGS, loss=adv_loss_adv,
             metrics_to_add=[
                 adv_acc_metric_adv,
-                # tf.keras.metrics.AUC(),
+                tf.keras.metrics.AUC(),
                 # adv_auc_metric_adv
             ]
         )


### PR DESCRIPTION
Fix an issue with training which was freezing network weights. The casue was calls to `tf.global_variables_initializer()` and `tf.local_variables_initializer()` which were necessary to use the `tf.metrics.auc` operations in the adversarial AUC metrics. Instead, we simply don't record the adversarial AUC during training; we will only collect this on the evaluation scripts (which use the Keras object, not the tensorflow function, to compute AUC).